### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk upgrade --no-cache --available && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -26,8 +25,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 COPY entrypoint.sh ./
 RUN chmod +x ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ RUN apk upgrade --no-cache --available && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline

--- a/package.json
+++ b/package.json
@@ -41,10 +41,5 @@
     "tsx": "4.21.0",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能および Docker ビルドにおけるバージョン不一致問題への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。また、Docker ビルド環境では `package.json` の有無によって corepack が選択する pnpm バージョンが変わり、バージョン不一致が発生します。

### 発生するエラー

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる
- `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]`: Docker ビルド環境でのバージョン不一致によりモジュール削除の確認が発生し、TTY がないため失敗

### 根本原因（Docker）

従来の Dockerfile では `pnpm fetch` 実行時に `package.json` が存在しないため corepack が pnpm v11 を使用し、その後 `pnpm install` 実行時に `package.json` が COPY されることで corepack が pnpm v10（`packageManager` フィールドの値）を使用します。このバージョン不一致により node_modules の削除確認プロンプトが表示されますが、Docker 環境には TTY がないため失敗します。

### 修正

1. `pnpm-workspace.yaml` に `allowBuilds` を追加し、esbuild のビルドスクリプトを明示的に許可
2. Dockerfile の COPY 順序を変更し、`pnpm fetch` 前に `package.json` と `pnpm-workspace.yaml` を COPY することで両ステップで同じ pnpm バージョンを使用するよう修正
3. Dockerfile から `pnpm approve-builds` の呼び出しを削除（`allowBuilds` 設定で代替）

```dockerfile
# 修正後の COPY 順序
COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
COPY tsconfig.json ./
COPY src src
RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
```

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)