### PR TITLE
fix: pnpm v11 動作に必要な Node.js を 24 LTS に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-# node:22-alpine から Node.js 22 のバイナリを取得するためのステージ
+# node:24-alpine から Node.js 24 のバイナリを取得するためのステージ
 # zenika/alpine-chrome のベース (Alpine 3.19) には Node.js 20 しか含まれないため、
-# pnpm v11 が必要とする node:sqlite (Node.js 22.5+) に対応するために Node.js 22 を使用する
-FROM node:22-alpine AS node22
+# pnpm v11 が必要とする node:sqlite (Node.js 22.5+) に対応するために Node.js 24 を使用する
+# プロジェクトの .node-version で指定されている Node.js 24 系と統一する
+FROM node:24-alpine AS node24
 
 FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
 
-# node:22-alpine から Node.js 22 のバイナリ・ライブラリ一式をコピーして上書きする
-COPY --from=node22 /usr/local/bin/node /usr/local/bin/node
-COPY --from=node22 /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node22 /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node22 /usr/local/bin/corepack /usr/local/bin/corepack
-COPY --from=node22 /usr/local/lib/node_modules /usr/local/lib/node_modules
+# node:24-alpine から Node.js 24 のバイナリ・ライブラリ一式をコピーして上書きする
+COPY --from=node24 /usr/local/bin/node /usr/local/bin/node
+COPY --from=node24 /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node24 /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node24 /usr/local/bin/corepack /usr/local/bin/corepack
+COPY --from=node24 /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
+# node:22-alpine から Node.js 22 のバイナリを取得するためのステージ
+# zenika/alpine-chrome のベース (Alpine 3.19) には Node.js 20 しか含まれないため、
+# pnpm v11 が必要とする node:sqlite (Node.js 22.5+) に対応するために Node.js 22 を使用する
+FROM node:22-alpine AS node22
+
 FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
+
+# node:22-alpine から Node.js 22 のバイナリ・ライブラリ一式をコピーして上書きする
+COPY --from=node22 /usr/local/bin/node /usr/local/bin/node
+COPY --from=node22 /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node22 /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node22 /usr/local/bin/corepack /usr/local/bin/corepack
+COPY --from=node22 /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
@@ -13,7 +25,6 @@ RUN apk upgrade --no-cache --available && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
-  npm install -g corepack@latest && \
   corepack enable
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# node:24-alpine から Node.js 24 のバイナリを取得するためのステージ
+# node:24.15.0-alpine から Node.js 24 のバイナリを取得するためのステージ
 # zenika/alpine-chrome のベース (Alpine 3.19) には Node.js 20 しか含まれないため、
 # pnpm v11 が必要とする node:sqlite (Node.js 22.5+) に対応するために Node.js 24 を使用する
-# プロジェクトの .node-version で指定されている Node.js 24 系と統一する
-FROM node:24-alpine AS node24
+# プロジェクトの .node-version (24.15.0) に合わせてパッチバージョンまで固定する
+FROM node:24.15.0-alpine AS node24
 
 FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ FROM node:24-alpine AS node24
 
 FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
 
-# node:24-alpine から Node.js 24 のバイナリ・ライブラリ一式をコピーして上書きする
+# node:24-alpine から Node.js 24 のバイナリとモジュールをコピーして上書きする
+# 注意: COPY --from はシンボリックリンクを解決してコピーするため、
+# npm/npx/corepack のシンボリックリンクは RUN ステップで再作成する必要がある
 COPY --from=node24 /usr/local/bin/node /usr/local/bin/node
-COPY --from=node24 /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node24 /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node24 /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node24 /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 ENV PNPM_HOME="/pnpm"
@@ -26,6 +25,9 @@ RUN apk upgrade --no-cache --available && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
+  ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+  ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+  ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
   corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## 概要

pnpm v11 が必要とする `node:sqlite` モジュール (Node.js 22.5+ で追加) が、現在の Docker イメージに含まれる Node.js 20 では利用できないため、Docker ビルドが失敗していた問題を修正します。

## 問題の詳細

- **エラー**: `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`
- **原因**: `zenika/alpine-chrome:with-puppeteer-xvfb` は Alpine 3.19 ベースで、Alpine 3.19 の `nodejs` パッケージは v20.x
- **発生条件**: pnpm v11 を `corepack` 経由で実行した際 (Renovate PR #2273 で確認)

## 修正内容

マルチステージビルドを導入し、`node:24-alpine` から Node.js 24 のバイナリと node_modules を `zenika/alpine-chrome:with-puppeteer-xvfb` ランナーステージにコピーします。

`node:24-alpine` を採用した理由:
- プロジェクトの `.node-version` が Node.js 24.15.0 を指定しており、バージョンを統一するため
- Node.js 22.5+ で追加された `node:sqlite` を含むため、pnpm v11 の要件を満たす

### 実装のポイント

`COPY --from` はシンボリックリンクを解決してファイルとしてコピーするため、`npm`/`npx`/`corepack` をそのままコピーすると、スクリプト内の相対 `require()` パスが `__dirname` (`/usr/local/bin`) から解決されてしまいモジュールが見つからないエラーが発生します。

このため、`/usr/local/bin/node` (バイナリ) のみを COPY し、`npm`/`npx`/`corepack` は `node_modules` 内の実際のスクリプトへのシンボリックリンクとして `ln -sf` で再作成します。

### 変更点

| 変更前 | 変更後 |
|--------|--------|
| Node.js 20.x (Alpine 3.19 apk パッケージ) | Node.js 24.x (`node:24-alpine` からコピー) |
| `npm install -g corepack@latest` でインストール | `node:24-alpine` 同梱の corepack を使用 |

### Dockerfile の構成

```dockerfile
FROM node:24-alpine AS node24

FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner

# node バイナリと node_modules をコピー
COPY --from=node24 /usr/local/bin/node /usr/local/bin/node
COPY --from=node24 /usr/local/lib/node_modules /usr/local/lib/node_modules

# npm/npx/corepack はシンボリックリンクとして再作成
RUN ... && \
  ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
  ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
  ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
  corepack enable
```

## 関連

- Renovate PR #2273 (`chore(deps): update pnpm to v11`) の Docker CI 失敗を解消するための先行修正
- pnpm v11 の Node.js 22 要件: https://pnpm.io/installation#compatibility