### PR TITLE
fix: TypeScript v6 に対応した tsconfig.json の修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "rootDir": "./src",
     "outDir": "./dist",
@@ -23,11 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF",
+    "types": ["node"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 に対応するため、`tsconfig.json` を修正します。

## 変更内容

### `moduleResolution` の変更
- **変更前**: `"moduleResolution": "Node"`
- **変更後**: `"moduleResolution": "bundler"`
- `Node` は TypeScript 6.0 で非推奨となったため、推奨の `bundler` に変更

### `ignoreDeprecations` の削除
- `"ignoreDeprecations": "6.0"` を削除
- この設定は TypeScript 7.0 で機能しなくなるため、根本対応として削除

### `baseUrl` の削除と `paths` のパス形式変更
- `"baseUrl": "."` を削除
- `paths` のパスを `"src/*"` から `"./src/*"` に変更（相対パス形式）

### `types` に `node` を追加
- `"types": ["node"]` を追加
- TypeScript 6.0 から `@types/node` の自動ロードが廃止されたため、明示的に指定

## 動作確認

- `tsc --noEmit` によるビルドが正常に完了
- `pnpm lint` が全項目通過

Fixes #2372