### PR TITLE
fix: eslint-plugin-unicorn v65 対応 (no-incorrect-query-selector, prefer-split-limit)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -220,8 +220,8 @@ function saveAllCsv() {
       .map((row) => {
         const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)
-        const month = date.split('/', 2)[0]
-        const day = date.split('/', 2)[1]
+        // date.split('/', 2) を 1 度だけ呼び出してデストラクチャリングで取得する
+        const [month, day] = date.split('/', 2)
         return [`${year}/${month}/${day}`, ...row.slice(1)]
       })
       .map((row) => row.map((col) => `"${col}"`))
@@ -268,8 +268,8 @@ function saveAllTsv() {
       .map((row) => {
         const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)
-        const month = date.split('/', 2)[0]
-        const day = date.split('/', 2)[1]
+        // date.split('/', 2) を 1 度だけ呼び出してデストラクチャリングで取得する
+        const [month, day] = date.split('/', 2)
         return [`${year}/${month}/${day}`, ...row.slice(1)]
       })
       .map((row) => row.join('\t'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,8 @@ async function save(config: Config, page: Page) {
     fullPage: true,
   })
   let html = await page.evaluate(() => {
-    return document.querySelectorAll('html')[0].innerHTML
+    // querySelectorAll('html')[0] の代わりに documentElement を使用する (unicorn/no-incorrect-query-selector)
+    return document.documentElement.innerHTML
   })
   const url = config.moneyforward.base_url
   html = html.replaceAll('href="/', `href="${url}`)
@@ -211,16 +212,16 @@ function saveAllCsv() {
   for (const file of csvFiles) {
     const tsv = fs.readFileSync(`/data/csv/${file}`, 'utf8')
     const rows = tsv.split('\n').slice(1)
-    const filedate = file.split(' - ')[0] // 20210101
+    const filedate = file.split(' - ', 1)[0] // 20210101
     const allCsv = rows
       .filter((row) => row.length > 0)
       .map((row) => row.split(',').map((col) => col.replace(/^"(.+)"$/, '$1')))
       .map((row) => row.filter((_, index) => index in columns))
       .map((row) => {
-        const date = row[0].split('(')[0]
+        const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)
-        const month = date.split('/')[0]
-        const day = date.split('/')[1]
+        const month = date.split('/', 2)[0]
+        const day = date.split('/', 2)[1]
         return [`${year}/${month}/${day}`, ...row.slice(1)]
       })
       .map((row) => row.map((col) => `"${col}"`))
@@ -259,16 +260,16 @@ function saveAllTsv() {
   for (const file of tsvFiles) {
     const tsv = fs.readFileSync(`/data/tsv/${file}`, 'utf8')
     const rows = tsv.split('\n').slice(1)
-    const filedate = file.split(' - ')[0] // 20210101
+    const filedate = file.split(' - ', 1)[0] // 20210101
     const allTsv = rows
       .filter((row) => row.length > 0)
       .map((row) => row.split('\t'))
       .map((row) => row.filter((_, index) => index in columns))
       .map((row) => {
-        const date = row[0].split('(')[0]
+        const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)
-        const month = date.split('/')[0]
-        const day = date.split('/')[1]
+        const month = date.split('/', 2)[0]
+        const day = date.split('/', 2)[1]
         return [`${year}/${month}/${day}`, ...row.slice(1)]
       })
       .map((row) => row.join('\t'))


### PR DESCRIPTION
## 概要

`@book000/eslint-config` の更新 (eslint-plugin-unicorn v65 系) に伴い新たに有効化されたルールへの違反を修正します。

## 変更内容

### unicorn/no-incorrect-query-selector (src/main.ts:127)

`querySelectorAll('html')[0].innerHTML` のように「最初の要素だけ使う」パターンを修正しました。

- **変更前**: `document.querySelectorAll('html')[0].innerHTML`
- **変更後**: `document.documentElement.innerHTML`

`document.documentElement` はドキュメントのルート要素（常に `<html>` 要素）を返すため、非 null アサーション不要で最も簡潔な表現です。

### unicorn/prefer-split-limit (src/main.ts:214, 220, 222/223, 262, 268, 270/271)

`String#split()` に、実際に使用する要素数に応じた `limit` 引数を追加しました。

また Copilot レビューの指摘を受け、同一の `date.split('/', 2)` を 2 回呼び出していた箇所をデストラクチャリングで 1 回の呼び出しにまとめました。

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `file.split(' - ')[0]` | `file.split(' - ', 1)[0]` | `[0]` のみ使用 → limit = 1 |
| `row[0].split('(')[0]` | `row[0].split('(', 1)[0]` | `[0]` のみ使用 → limit = 1 |
| `date.split('/')[0]` + `date.split('/')[1]` | `const [month, day] = date.split('/', 2)` | デストラクチャリングで split 呼び出しを 1 回に統合 |

同じパターンが CSV 処理 (`saveAllCsv`) と TSV 処理 (`saveAllTsv`) の両方に存在するため、両方修正しました。

## 確認事項

- `pnpm lint` 通過済み（prettier / eslint / tsc すべて OK）
- 機能変更なし（split の limit 追加とデストラクチャリングは結果同一、不要な処理を削減）

- Fixes #2376