### PR TITLE
fix: eslint-config 1.16.3 の unicorn ルール更新に伴う lint エラーを修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -128,8 +128,8 @@ async function save(config: Config, page: Page) {
     return document.documentElement.innerHTML
   })
   const url = config.moneyforward.base_url
-  html = html.replaceAll('href="/', `href="${url}`)
-  html = html.replaceAll('src="/', `src="${url}`)
+  html = html.replaceAll('href="/', () => `href="${url}`)
+  html = html.replaceAll('src="/', () => `src="${url}`)
   fs.writeFileSync(`/data/html/${filename}.html`, html)
 }
 
@@ -216,7 +216,7 @@ function saveAllCsv() {
     const allCsv = rows
       .filter((row) => row.length > 0)
       .map((row) => row.split(',').map((col) => col.replace(/^"(.+)"$/, '$1')))
-      .map((row) => row.filter((_, index) => index in columns))
+      .map((row) => row.filter((_, index) => Object.hasOwn(columns, index)))
       .map((row) => {
         const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)
@@ -264,7 +264,7 @@ function saveAllTsv() {
     const allTsv = rows
       .filter((row) => row.length > 0)
       .map((row) => row.split('\t'))
-      .map((row) => row.filter((_, index) => index in columns))
+      .map((row) => row.filter((_, index) => Object.hasOwn(columns, index)))
       .map((row) => {
         const date = row[0].split('(', 1)[0]
         const year = getYear(filedate, date)


### PR DESCRIPTION
## 背景

Renovate PR #2398 が `@book000/eslint-config` を 1.15.4 -> 1.16.3 に更新しようとしていますが、新しい `eslint-plugin-unicorn` ルールが `src/main.ts` の既存コードを検出し、CI の `Node CI / node-ci (.)` と `Node CI / Check finished Node CI` が失敗しています。

このプルリクエストは、CI を通すために該当箇所を機械的に修正するものです。Renovate PR 自体には手を入れていません。

## 修正内容

- `unicorn/no-unsafe-string-replacement`（2 件）: `html.replaceAll('href="/', ...)` / `.replaceAll('src="/', ...)` の置換値をリテラル文字列から関数に変更（挙動は変わりません）
- `unicorn/no-computed-property-existence-check`（2 件）: `index in columns` を `Object.hasOwn(columns, index)` に置換（`columns` はプレーンオブジェクトのため、プロトタイプチェーンを辿らない分、より安全なチェックになります）

## 動作確認

- `@book000/eslint-config@1.16.3` を一時的に導入して `pnpm run lint`（prettier + eslint + tsc）がクリーンになることを確認
- 元の `1.15.4` でも `pnpm run lint` が引き続き通ることを確認（デグレなし）

いずれも挙動を変えない機械的な lint 修正です。