### PR TITLE
feat: GlitchTip へのエラー送信を有効化する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ MoneyForward の入出金明細を Puppeteer で自動収集し、CSV/TSV/HTML/P
 - **エラーハンドリング**: Puppeteer 操作や外部サイトへの依存箇所で try-catch により適切に捕捉・ログ出力されているか。定期実行のため 1 回の失敗で全体が停止しない設計か。
 - **型安全性**: `skipLibCheck` や `any` による型エラーの握りつぶしがないか（strict モード維持）。
 - **JSDoc**: 関数・インターフェースに日本語の JSDoc が付与・更新されているか。
+- **エラー報告への機密情報混入**: `logger.error()` および `ErrorReporter.captureException()` は、`SENTRY_DSN` 設定時に GlitchTip (Sentry) へエラーを転送する意図的な実装である。`ErrorReporter.captureException` に渡す `context`/`extra` や、`logger.error()` でログ出力するエラーオブジェクトに、パスワード・個人情報などの機密情報が含まれていないか確認する。
 
 ## フラグすべきでない既知パターン
 
@@ -36,8 +37,10 @@ MoneyForward の入出金明細を Puppeteer で自動収集し、CSV/TSV/HTML/P
 - **テストの不在**: テストフレームワークは導入しておらず、動作確認は実 MoneyForward 環境での手動テストで行う。「テストを追加すべき」という一般論の指摘は不要。
 - **`|| true` による継続**: `entrypoint.sh` の `pnpm start || true` は定期実行で失敗しても継続させる意図的な設計。
 - **Renovate PR**: Renovate が作成した依存更新 PR への追加コミットは行わない運用。
+- **`logger.error()` と `ErrorReporter.captureException()` の併用**: 同一の catch ブロック内で両方を呼び出すのは意図的な設計であり、重複した指摘は不要。前者は `SENTRY_DSN` 設定時に winston トランスポート経由で自動転送され、後者はタグ付きの構造化コンテキストを付与した明示的な報告を行うという別の役割を持つ。
 
 ## セキュリティ
 
 - 認証情報・個人情報を含むファイルはコミットしない。リポジトリにはサンプル設定のみを含める。
 - ログにパスワード・トークン・個人情報を出力しない。
+- GlitchTip/Sentry へ送信されるエラー報告にも、ログと同様に認証情報・個人情報を含めない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,10 @@ CONFIG_PATH=/data/config.json
 CHROMIUM_PATH=/usr/bin/chromium-browser
 LOG_DIR=/data/logs/
 USER_DATA_BASE=/data/userdata
+SENTRY_DSN=  # オプション。設定すると GlitchTip (Sentry 互換) へのエラー送信が有効化される
 ```
+
+- `SENTRY_DSN` を設定すると、`@book000/node-utils` の `Logger`/`ErrorReporter` が自動的に GlitchTip (Sentry 互換) へエラーを転送する。未設定の場合は何も送信されない（opt-in）。関連するオプション環境変数として `SENTRY_ENVIRONMENT`（環境名）、`SENTRY_LOG_LEVEL`（転送する最小ログレベル）、`SENTRY_RELEASE`（リリースタグ）がある。
 
 ### 出力ディレクトリ（自動作成）
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import puppeteer, { LaunchOptions, Page } from 'puppeteer-core'
-import { Logger } from '@book000/node-utils'
+import { ErrorReporter, Logger } from '@book000/node-utils'
 
 interface Config {
   moneyforward: {
@@ -361,6 +361,8 @@ async function main() {
     await main()
   } catch (error) {
     logger.error('main() error', error as Error)
+    // SENTRY_DSN が設定されている場合、GlitchTip へタグ付きでエラーを送信する
+    ErrorReporter.captureException(error as Error, { phase: 'main' })
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit(1)
   }


### PR DESCRIPTION
## 概要

GlitchTip (Sentry 互換) へのエラー送信に対応しました。`@book000/node-utils` 1.25.8 が Sentry(GlitchTip) 連携を内蔵しているため、実行環境で `SENTRY_DSN` 環境変数を設定するだけで既存の `logger.error()` 呼び出しが自動的に GlitchTip へ転送されます。加えて、トップレベルの未処理例外ハンドラに `ErrorReporter.captureException()` を追加し、タグ付き(`phase: 'main'`)の明示的なエラーレポートも送信するようにしました。

## 変更内容

- `src/main.ts`: トップレベルの `catch` ブロックで `ErrorReporter.captureException(error as Error, { phase: 'main' })` を呼び出すよう追加(`@book000/node-utils` から `ErrorReporter` をインポート)
- `CLAUDE.md`: Docker 環境変数一覧に `SENTRY_DSN` を追加し、GlitchTip 連携の挙動(opt-in、関連するオプション環境変数 `SENTRY_ENVIRONMENT` / `SENTRY_LOG_LEVEL` / `SENTRY_RELEASE`)を説明する記述を追加
- `.github/copilot-instructions.md`: レビュー観点に、エラー報告への機密情報混入チェックと、`logger.error()` と `ErrorReporter.captureException()` の併用が意図的な設計である旨のフラグ抑止パターンを追加

## 背景

book000/book000#131 の調査により、本リポジトリは追加のコード変更なしで GlitchTip 連携に対応可能と判断されました(詳細は Issue 本文を参照)。issue #131 が想定する `Sentry.init()` を自前で呼ぶパターンは、`@book000/node-utils` 使用済みの本リポジトリには不要かつ二重実装のリスクがあるため採用していません。

Closes #2508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
